### PR TITLE
fix(theme): 修复深色主题下 markdown 代码块显示问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.7
+
+_2025-05-26_
+
+### Bug fixes
+
+- [#105](https://github.com/Z-J-wang/render-jupyter-notebook-vue/issues/105) markdown code 的主题为不会随着深色主题的切换而切换
+
 ## 2.2.6
 
 _2025-05-07_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "render-jupyter-notebook-vue",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "license": "MIT",
   "homepage": "https://z-j-wang.github.io/render-jupyter-notebook-vue/#/",
   "repository": "https://github.com/Z-J-wang/render-jupyter-notebook-vue",

--- a/src/assets/css/jupyterlab/highlight.theme.css
+++ b/src/assets/css/jupyterlab/highlight.theme.css
@@ -1,0 +1,7 @@
+/* 此文件为 highlight 主题样式文件，声明了暗模式和亮模式的的样式生效文件 */
+
+/* 暗模式使用暗主题 */
+@import url('highlight.js/styles/github-dark.min.css') (prefers-color-scheme: dark);
+
+/* 亮模式或者不支持暗模式的时候使用亮主题 */
+@import url('highlight.js/styles/github.css') (prefers-color-scheme: light) or (prefers-color-scheme: no-preference);

--- a/src/layout/DefaultLayout.vue
+++ b/src/layout/DefaultLayout.vue
@@ -24,7 +24,7 @@
           </div>
         </div>
       </el-header>
-      <el-main class="mx-auto mt-4 mb-20 w-full dark:bg-black">
+      <el-main class="mx-auto mt-4 mb-20 w-full bg-white dark:bg-black">
         <slot />
       </el-main>
 

--- a/src/utils/notebook/markdown.it.js
+++ b/src/utils/notebook/markdown.it.js
@@ -1,6 +1,6 @@
 import markdown from 'markdown-it';
 import hljs from 'highlight.js';
-import 'highlight.js/styles/github.css';
+import '../../assets/css/jupyterlab/highlight.theme.css';
 
 export default markdown({
   html: true,


### PR DESCRIPTION
- 更新 highlight.js 主题样式，支持深色和浅色主题自动切换
- 修改 el-main 背景颜色，确保在深色主题下正确显示
- 更新 markdown 渲染器配置，使用新的主题样式文件